### PR TITLE
Ensure UInt64 binary & operator usage

### DIFF
--- a/Source/Internal/Utility/AdClearIdUtil.swift
+++ b/Source/Internal/Utility/AdClearIdUtil.swift
@@ -51,7 +51,7 @@ public struct AdClearId {
     }
 
     private static func limitBitsTo(value: UInt64, maxBits: UInt64) -> UInt64 {
-        let maxLength = (1 << maxBits) - 1
+        let maxLength: UInt64 = (1 << maxBits) - 1
 
         return value & maxLength
     }


### PR DESCRIPTION
Fix issue #60 by including explicit type declarations, i.e., `UInt64` for binary `&` operator usage.