### PR TITLE
Adjust the project so that xcframeworks are supported

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,24 @@ Carthage support starting from version 4.6.0
 
 `github "Webtrekk/webtrekk-ios-sdk"`
 
+## xcframework
+
+Run the following (adjusted) commands in the command line.
+
+1. Create the framework for devices' architectures:
+
+```xcodebuild archive -scheme "Webtrekk-iOS" -destination="iOS" -archivePath "/tmp/webtrekk/wt-ios.xcarchive" -sdk "iphoneos" SKIP_INSTALL=NO```
+
+2. Create the framework for the simulator's architectures:
+
+```xcodebuild archive -scheme "Webtrekk-iOS" -destination="iOS Simulator" -archivePath "/tmp/webtrekk/wt-simulator.xcarchive" -sdk "iphonesimulator" SKIP_INSTALL=NO```
+
+3. Combine both into a xcframework:
+
+```xcodebuild -create-xcframework -framework /tmp/webtrekk/wt-simulator.xcarchive/Products/Library/Frameworks/Webtrekk.framework -framework /tmp/webtrekk/wt-ios.xcarchive/Products/Library/Frameworks/Webtrekk.framework -output Webtrekk.xcframework```
+
+4. Copy the xcframework to a path of your choice and link (and copy) it in your iOS target.
+
 # SwiftLint
 
 We use Swiftlint from [Realm](https://realm.io/) to lint our code. SwiftLint has to be installed on your device. 

--- a/Source/Internal/Utility/CatchObC.h
+++ b/Source/Internal/Utility/CatchObC.h
@@ -6,9 +6,6 @@
 //
 //
 
-#ifndef CatchObC_h
-#define CatchObC_h
-
 #import <Foundation/Foundation.h>
 
 @interface CatchObC : NSObject
@@ -16,5 +13,3 @@
 + (BOOL)catchException:(void(^)(void))tryBlock error:(__autoreleasing NSError **)error;
     
 @end
-
-#endif /* CatchObC_h */

--- a/Source/Public/Properties/CrossDeviceProperties.swift
+++ b/Source/Public/Properties/CrossDeviceProperties.swift
@@ -1,3 +1,5 @@
+import Foundation
+
 /** Enhance tracking by adding properties to track users across different devices. */
 public struct CrossDeviceProperties {
 

--- a/Source/Webtrekk-Bridging-Header.h
+++ b/Source/Webtrekk-Bridging-Header.h
@@ -1,6 +1,0 @@
-#ifndef Webtrekk_Bridging_Header_h
-#define Webtrekk_Bridging_Header_h
-
-#import <Webtrekk/CatchObC.h>
-
-#endif /* Webtrekk_Bridging_Header_h */

--- a/Source/Webtrekk.h
+++ b/Source/Webtrekk.h
@@ -1,5 +1,7 @@
 #import <UIKit/UIKit.h>
 
+#import <Webtrekk/CatchObC.h>
+
 //! Project version number for Webtrekk.
 FOUNDATION_EXPORT double WebtrekkVersionNumber;
 

--- a/Webtrekk.xcodeproj/project.pbxproj
+++ b/Webtrekk.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 52;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -28,7 +28,6 @@
 		0F2D21EF1EDEA1C500D09ADF /* XmlTrackerConfigurationParser.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D219B1EDEA1C500D09ADF /* XmlTrackerConfigurationParser.swift */; };
 		0F2D21F01EDEA1C500D09ADF /* AdClearIdUtil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D219D1EDEA1C500D09ADF /* AdClearIdUtil.swift */; };
 		0F2D21F11EDEA1C500D09ADF /* ASIdentifierManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D219E1EDEA1C500D09ADF /* ASIdentifierManager.swift */; };
-		0F2D21F21EDEA1C500D09ADF /* CatchObC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2D219F1EDEA1C500D09ADF /* CatchObC.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0F2D21F31EDEA1C500D09ADF /* CatchObC.m in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21A01EDEA1C500D09ADF /* CatchObC.m */; };
 		0F2D21F41EDEA1C500D09ADF /* ClosedInterval.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21A11EDEA1C500D09ADF /* ClosedInterval.swift */; };
 		0F2D21F51EDEA1C500D09ADF /* Dictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21A21EDEA1C500D09ADF /* Dictionary.swift */; };
@@ -73,7 +72,7 @@
 		0F2D221E1EDEA1C500D09ADF /* ExceptionTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D01EDEA1C500D09ADF /* ExceptionTracker.swift */; };
 		0F2D221F1EDEA1C500D09ADF /* MediaTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D11EDEA1C500D09ADF /* MediaTracker.swift */; };
 		0F2D22201EDEA1C500D09ADF /* PageTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D21EDEA1C500D09ADF /* PageTracker.swift */; };
-		0F2D22211EDEA1C500D09ADF /* Recommendations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D31EDEA1C500D09ADF /* Recommendations.swift */; };
+		0F2D22211EDEA1C500D09ADF /* Recommendations.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D31EDEA1C500D09ADF /* Recommendations.swift */; platformFilter = ios; };
 		0F2D22221EDEA1C500D09ADF /* Tracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D41EDEA1C500D09ADF /* Tracker.swift */; };
 		0F2D22231EDEA1C500D09ADF /* TrackerError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D51EDEA1C500D09ADF /* TrackerError.swift */; };
 		0F2D22241EDEA1C500D09ADF /* TrackerRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F2D21D61EDEA1C500D09ADF /* TrackerRequest.swift */; };
@@ -127,6 +126,8 @@
 		5AF6D0682073DA6E002E98A3 /* Tests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6D0672073DA6E002E98A3 /* Tests.swift */; };
 		5AF6D06A2073DA6E002E98A3 /* Webtrekk.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 0F2D21791EDEA18500D09ADF /* Webtrekk.framework */; };
 		5AF6D0812073DC86002E98A3 /* RequestTrackerBuilderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AF6D0802073DC86002E98A3 /* RequestTrackerBuilderTests.swift */; };
+		651990122382FFFB002162D2 /* CatchObC.h in Headers */ = {isa = PBXBuildFile; fileRef = 0F2D219F1EDEA1C500D09ADF /* CatchObC.h */; platformFilter = ios; settings = {ATTRIBUTES = (Public, ); }; };
+		651990132383DDDF002162D2 /* Webtrekk.h in Headers */ = {isa = PBXBuildFile; fileRef = 0FE637891EDED5C1006887EC /* Webtrekk.h */; platformFilter = ios; settings = {ATTRIBUTES = (Public, ); }; };
 		9F4400231FDE887600F7CE04 /* ProductListTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4400221FDE887600F7CE04 /* ProductListTracker.swift */; };
 		9F4400251FDE893D00F7CE04 /* ProductListTrackerImpl.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F4400241FDE893D00F7CE04 /* ProductListTrackerImpl.swift */; };
 		9F49813C1F9F975700BFD9F1 /* AppIntstallGoal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F49813B1F9F975700BFD9F1 /* AppIntstallGoal.swift */; };
@@ -231,7 +232,6 @@
 		0FE637851EDED536006887EC /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = System/Library/Frameworks/AVFoundation.framework; sourceTree = SDKROOT; };
 		0FE637881EDED5C1006887EC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		0FE637891EDED5C1006887EC /* Webtrekk.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Webtrekk.h; sourceTree = "<group>"; };
-		0FE6378A1EDED7AD006887EC /* Webtrekk-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Webtrekk-Bridging-Header.h"; sourceTree = "<group>"; };
 		5A4D1F8022942AB9006501AA /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		5A4D20BD22942C40006501AA /* UInt64+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UInt64+Extension.swift"; sourceTree = "<group>"; };
 		5A4D20C522942C40006501AA /* Int+Extension.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Int+Extension.swift"; sourceTree = "<group>"; };
@@ -543,7 +543,6 @@
 				0FE637881EDED5C1006887EC /* Info.plist */,
 				0FE637891EDED5C1006887EC /* Webtrekk.h */,
 				0F2D21DC1EDEA1C500D09ADF /* WebtrekkTracking.swift */,
-				0FE6378A1EDED7AD006887EC /* Webtrekk-Bridging-Header.h */,
 			);
 			path = Source;
 			sourceTree = "<group>";
@@ -617,7 +616,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				0F2D21F21EDEA1C500D09ADF /* CatchObC.h in Headers */,
+				651990122382FFFB002162D2 /* CatchObC.h in Headers */,
+				651990132383DDDF002162D2 /* Webtrekk.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1099,6 +1099,7 @@
 		0F2D21821EDEA18500D09ADF /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
@@ -1119,7 +1120,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Webtrekk.Webtrekk;
 				PRODUCT_NAME = Webtrekk;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Source/Webtrekk-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Debug;
@@ -1127,6 +1127,7 @@
 		0F2D21831EDEA18500D09ADF /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				BUILD_LIBRARY_FOR_DISTRIBUTION = YES;
 				CODE_SIGN_IDENTITY = "";
 				DEFINES_MODULE = YES;
 				DEVELOPMENT_TEAM = EZPY3L3K5H;
@@ -1146,7 +1147,6 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.Webtrekk.Webtrekk;
 				PRODUCT_NAME = Webtrekk;
 				SKIP_INSTALL = YES;
-				SWIFT_OBJC_BRIDGING_HEADER = "Source/Webtrekk-Bridging-Header.h";
 				SWIFT_VERSION = 4.2;
 			};
 			name = Release;

--- a/Webtrekk.xcodeproj/xcshareddata/xcschemes/Webtrekk-iOS.xcscheme
+++ b/Webtrekk.xcodeproj/xcshareddata/xcschemes/Webtrekk-iOS.xcscheme
@@ -26,12 +26,10 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      codeCoverageEnabled = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
       </Testables>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -52,8 +50,6 @@
             ReferencedContainer = "container:Webtrekk.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"


### PR DESCRIPTION
- removed the bridging header so that the framework target Is _officially_ supported
- changed _BUILD_LIBRARY_FOR_DISTRIBUTION_
- added instructions for xcframework to readme

This should not break compatibility with Cocoapods/Carthage.

Some developers do not want to use external dependency managers so the only way to include the SDK was to add it as a subproject. Doing this, all warning (or even errors) pop up when the developer's project is built. Most of the time, the developer does not care about the SDK's internals so inheriting the warnings is – sorry – pita.

Creating an xcframework enables to include the SDK in the project without having it build every time the developer's project is built.